### PR TITLE
Fix ExecStartPost directory creation

### DIFF
--- a/conf/spire-agent.service
+++ b/conf/spire-agent.service
@@ -37,6 +37,6 @@ EnvironmentFile=-/var/lib/spire/conf/join_token
 ExecStartPre=/usr/bin/configure-spire.sh
 ExecStart=/usr/bin/spire-agent run -expandEnv -config /var/lib/spire/conf/spire-agent.conf
 StandardOutput=journal
-ExecStartPost=+bash -c 'mkdir /root/spire && ln -sf /var/lib/spire/agent.sock /root/spire/agent.sock'
+ExecStartPost=+bash -c 'mkdir -p /root/spire && ln -sf /var/lib/spire/agent.sock /root/spire/agent.sock'
 Restart=always
 RestartSec=10s


### PR DESCRIPTION
### Summary and Scope

- Fixes:
If /root/spire existed before spire-agent.service runs (ex. on service restart), the unit fails. This just adds the '-p' flag to mkdir.

#### Issue Type

- Bugfix Pull Request

### Prerequisites

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency

 Adding idempotency with this PR.

### Risks and Mitigations
 