### PR TITLE
CASMTRIAGE-6061: revert to previous bin path

### DIFF
--- a/spire-agent.spec
+++ b/spire-agent.spec
@@ -49,7 +49,7 @@ Requires(postun): /usr/sbin/userdel
 %define spire_binary bin/spire-agent
 
 %define spire_agent_dir /var/lib/spire
-%define spire_bin_dir /usr/bin/
+%define spire_bin_dir /opt/cray/cray-spire
 
 %description
 SPIFFE SPIRE Agent binary distribution.
@@ -63,8 +63,8 @@ make build
 
 %install
 mkdir -p %{buildroot}%{spire_agent_dir}/{data,conf,bundle}
-install -D -m 0755 %{vendor_dir}/bin/spire-agent %{buildroot}%{_bindir}/spire-agent
-install -D -m 0755 conf/configure-spire.sh %{buildroot}%{_bindir}/configure-spire.sh
+install -D -m 0700 %{vendor_dir}/bin/spire-agent %{buildroot}%{spire_bin_dir}/spire-agent
+install -D -m 0700 conf/configure-spire.sh %{buildroot}%{spire_bin_dir}/configure-spire.sh
 install -D -m 0644 conf/spire-agent.service %{buildroot}%{_unitdir}/spire-agent.service
 
 %clean
@@ -73,8 +73,8 @@ rm -rf %{buildroot}
 %files
 %defattr(-,root,root)
 %doc README.adoc
-%attr(755,root,root) %{spire_bin_dir}/spire-agent
-%attr(755,root,root) %{spire_bin_dir}/configure-spire.sh
+%attr(700,root,root) %{spire_bin_dir}/spire-agent
+%attr(700,root,root) %{spire_bin_dir}/configure-spire.sh
 %attr(644,root,root) %{_unitdir}/spire-agent.service
 %attr(700,spire,spire) %dir %{spire_agent_dir}/data
 %attr(700,spire,spire) %dir %{spire_agent_dir}/conf


### PR DESCRIPTION
### Summary and Scope

Spire bin dir needs to be  /opt/cray/cray-spire for security purposes.


<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: CASMTRIAGE-6061

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [ ] I tested this on internal system (if yes, please include results or a description of the test)
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
