### PR TITLE
CASMPET-6937: Update spire config to have log level warning

### DIFF
--- a/conf/configure-spire.sh
+++ b/conf/configure-spire.sh
@@ -97,7 +97,7 @@ rm -f /tmp/spire_bundle
 cat << EOF > "${spire_rootdir}/conf/spire-agent.conf"
 agent {
   data_dir = "${spire_rootdir}"
-  log_level = "INFO"
+  log_level = "WARN"
   server_address = "${spire_server}"
   server_port = "8081"
   socket_path = "${spire_rootdir}/agent.sock"


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMPET-6937](https://jira-pro.it.hpe.com:8443/browse/CASMPET-6937)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This changes the log level on spire-agent to WARN. This was chosen because of the amount of logs that the spire-agent gives can cause slowdowns on larger systems. On all internal systems the log messages for info are not needed and provide no helpful data. 

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
           Tested on tyr by changing the loglevel on the config file and restarting the service to ensure it started up.
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
 
### Risks and Mitigations
 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
There is no risk as this can be changed on the fly for systems if we need more logging for some reason, however it has never been useful logging to begin with.