### PR TITLE
CASMPET-7535: Update configure-spire script for TPM support

### DIFF
--- a/conf/configure-spire.sh
+++ b/conf/configure-spire.sh
@@ -29,7 +29,7 @@ spire_rootdir="/var/lib/spire"
 # Get boot parameters
 BOOT_PARAMS=$(</proc/cmdline)
 
-if [[ -f "${spire_rootdir}/conf/join_token" ]] && [[ -f "${spire_rootdir}/conf/spire-agent.conf" ]]; then
+if [[ -f "${spire_rootdir}/conf/join_token" || -f "${spire_rootdir}/conf/tpm.enabled"  ]] && [[ -f "${spire_rootdir}/conf/spire-agent.conf" ]]; then
     echo "Not recreating spire-agent.conf."
     exit 0
 fi
@@ -55,6 +55,19 @@ for word in ${BOOT_PARAMS}; do
         else
             printf "join_token=%s" "${join_token}" > "${spire_rootdir}/conf/join_token"
             chmod 600 "${spire_rootdir}/conf/join_token"
+        fi
+    fi
+
+    if [[ ${parent_key} == 'tpm' ]]; then
+        tpm_setting="${parent_val}"
+
+        if [[ ${tpm_setting} == 'enable' ]]; then
+            echo "Not recreating spire-agent.conf"
+            exit 0
+        elif [[ ${tpm_setting} == 'enroll' ]]; then
+            echo "TPM set to enroll"
+        else
+            echo >&2 "Unknown TPM setting ${tpm_setting}"
         fi
     fi
 done


### PR DESCRIPTION
### Summary and Scope

<!--- Pick one below and delete the rest -->
<!--- Add the JIRA (WORD-NUMBER), or use a hyper-link ([WORD-NUMBER](https://jira-pro.its.hpecorp.net:8443/browse/WORD-NUMBER)). -->

- Fixes: [CASMPET-7535](https://jira-pro.it.hpe.com:8443/browse/CASMPET-7535)

#### Issue Type

<!--- Delete un-needed bullets -->

- Bugfix Pull Request

<!--- words; describe what this change is and what it is for. -->
This updates the configure-spire script so it wont clobber the spire-config when TPM is enabled. This is helpful when a compute node is booted with TPM enabled. Before this change it would just overwrite the config when tpm was enabled because it never gets a join token. It likely still works due to the node already being joined during dracut but this PR will eliminate and confusion.

### Prerequisites

<!--- An empty check is two brackets with a space inbetween, a checked checkbox is two brackets with an x inbetween -->
<!--- unchecked checkbox: [ ] -->
<!--- checked checkbox: [x] -->
<!--- invalid checkbox: [] -->

- [x] I have included documentation in my PR (or it is not required)
- [x] I tested this on internal system (if yes, please include results or a description of the test)
Tested on Tyr while doing TPM testing.
- [ ] I tested this on a vshasta system (if yes, please include results or a description of the test)
 
### Idempotency
 
<!--- describe testing done to verify code changes behave in an idempotent manner -->
Only adds new checks so if idempotent before then remains. 

### Risks and Mitigations
 
I dont see any way this is more risky. 
<!--- What is less risky, or more risky now - or if your mod fails is there a new risk? -->
<!---
    Example:
    
    This introduces some risk since this change also brings in a newer version of X, but otherwise the original bugfix
    is resolved and the overall risk of fatal failures is reduced.
    
    -->
